### PR TITLE
Update settings.json.sample

### DIFF
--- a/settings.json.sample
+++ b/settings.json.sample
@@ -1,9 +1,9 @@
 {
-    "API_URL": "localhost:5417", # The API URL
-    "SECURE_HTTP": false, # Is the API protected by HTTPS?
-    "templates": { # Templates sample
-        "basic": { # Template name
-            "description": "Basic template", # Template description
+    "API_URL": "localhost:5417", 
+    "SECURE_HTTP": false, 
+    "templates": { 
+        "basic": { 
+            "description": "Basic template", 
             "matcher": "glob",
             "target": "*",
             "moduleFunction": "test.fib",


### PR DESCRIPTION
If the settings.json.sample is copied to the /opt/saltpad/settings.json and the "comments" starting with '#' are left in place, then the JSON parsing gets exceptions.

Those comments break the json parseing syntax.